### PR TITLE
Unbreak master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: python
 
 python:
-    - 2.7
-    - pypy
-    - 3.3
-    - 3.4
+    - 3.6
+    - 3.7
+    - 3.8
+    - 3.9
 
 install:
-   - pip install -U tox setuptools wheel $(python -V |& grep -q 'Python 3.2' && echo 'pip<8.0 virtualenv<14.0')
+   - pip install -U tox setuptools wheel
 script: tox

--- a/click_threading/__init__.py
+++ b/click_threading/__init__.py
@@ -21,7 +21,7 @@ try:
 except ImportError:
     from futures import Future as _Future
 
-__version__ = '0.4.4'
+__version__ = '0.5.0'
 
 _CTX_WORKER_KEY = __name__ + '.uiworker'
 

--- a/click_threading/monkey.py
+++ b/click_threading/monkey.py
@@ -40,12 +40,16 @@ def patch_ui_functions(wrapper):
 
         new_f = wrapper(_copy_fn(f), info)
 
-        argspec = getargspec(f)
-        signature = inspect.formatargspec(*argspec) \
-            .lstrip('(') \
-            .rstrip(')')
-        args = ', '.join(arg.split('=')[0].split(':')[0].strip()
-                         for arg in signature.split(','))
+        orig_sig_obj = inspect.signature(f)
+        sig_obj = orig_sig_obj.replace(
+            parameters=[
+                p.replace(annotation=inspect.Parameter.empty)
+                for p in orig_sig_obj.parameters.values()
+            ],
+            return_annotation=inspect.Signature.empty,
+        )
+        signature = str(sig_obj).lstrip('(').rstrip(')')
+        args = ', '.join(p for p in sig_obj.parameters.keys())
 
         stub_f = eval('lambda {s}: {n}._real_click_fn({a})'
                       .format(n=f.__name__, s=signature, a=args))

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,12 @@ setup(
     install_requires=[
         'click>=5.0',
     ],
-    extras_require={
-        ':python_version < "3.2"': 'futures'
-    }
+    python_requires=">=3.6",
+    classifiers=[
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+    ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -2,5 +2,5 @@
 passenv = LANG
 deps =
     pytest
-    git+https://github.com/mitsuhiko/click
+    click
 commands = py.test


### PR DESCRIPTION
This PR includes #5, and also updates the supported Python versions and the versions we run on CI.

I've included all Python versions currently supported upstream.

This should get back to a green master, which can be cut onto a new release. I'm can take over maintenance here, since this is kinda blocking `vdirsyncer`.